### PR TITLE
Make the LayerActivity inherit from AppCompatActivity

### DIFF
--- a/anylayer/src/main/java/per/goweii/anylayer/LayerActivity.java
+++ b/anylayer/src/main/java/per/goweii/anylayer/LayerActivity.java
@@ -41,6 +41,7 @@ public class LayerActivity extends AppCompatActivity implements Layer.OnVisibleC
 
   @Override
   public void onDismiss(@NonNull Layer layer) {
+    sOnLayerCreatedCallback = null;
     finish();
     overridePendingTransition(0, 0);
   }

--- a/anylayer/src/main/java/per/goweii/anylayer/LayerActivity.java
+++ b/anylayer/src/main/java/per/goweii/anylayer/LayerActivity.java
@@ -1,55 +1,55 @@
 package per.goweii.anylayer;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 
 import per.goweii.anylayer.dialog.DialogLayer;
 import per.goweii.anylayer.utils.Utils;
 
-public class LayerActivity extends Activity implements Layer.OnVisibleChangeListener {
+public class LayerActivity extends AppCompatActivity implements Layer.OnVisibleChangeListener {
 
-    @Nullable
-    private static OnLayerCreatedCallback sOnLayerCreatedCallback = null;
+  @Nullable
+  private static OnLayerCreatedCallback sOnLayerCreatedCallback = null;
 
-    static void start(@NonNull Context context, OnLayerCreatedCallback callback) {
-        sOnLayerCreatedCallback = callback;
-        Intent intent = new Intent(context, LayerActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        context.startActivity(intent);
+  static void start(@NonNull Context context, OnLayerCreatedCallback callback) {
+    sOnLayerCreatedCallback = callback;
+    Intent intent = new Intent(context, LayerActivity.class);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    context.startActivity(intent);
+  }
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    overridePendingTransition(0, 0);
+    super.onCreate(savedInstanceState);
+    Utils.transparent(this);
+    DialogLayer dialogLayer = AnyLayer.dialog(this);
+    dialogLayer.onVisibleChangeListener(this);
+    if (sOnLayerCreatedCallback != null) {
+      sOnLayerCreatedCallback.onLayerCreated(dialogLayer);
     }
-
-    @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        overridePendingTransition(0, 0);
-        super.onCreate(savedInstanceState);
-        Utils.transparent(this);
-        DialogLayer dialogLayer = AnyLayer.dialog(this);
-        dialogLayer.onVisibleChangeListener(this);
-        if (sOnLayerCreatedCallback != null) {
-            sOnLayerCreatedCallback.onLayerCreated(dialogLayer);
-        }
-    }
+  }
 
     @Override
     public void onShow(@NonNull Layer layer) {
     }
 
-    @Override
-    public void onDismiss(@NonNull Layer layer) {
-        finish();
-        overridePendingTransition(0, 0);
-    }
+  @Override
+  public void onDismiss(@NonNull Layer layer) {
+    finish();
+    overridePendingTransition(0, 0);
+  }
 
-    public interface OnLayerCreatedCallback {
-        /**
-         * 浮层已创建，可在这里进行浮层的初始化和数据绑定
-         */
-        void onLayerCreated(@NonNull DialogLayer dialogLayer);
-    }
+  public interface OnLayerCreatedCallback {
+    /**
+     * 浮层已创建，可在这里进行浮层的初始化和数据绑定
+     */
+    void onLayerCreated(@NonNull DialogLayer dialogLayer);
+  }
 
 }

--- a/anylayer/src/main/java/per/goweii/anylayer/dialog/DialogLayer.java
+++ b/anylayer/src/main/java/per/goweii/anylayer/dialog/DialogLayer.java
@@ -195,7 +195,11 @@ public class DialogLayer extends DecorLayer {
                         contentAnimator = AnimatorHelper.createTopInAnim(view);
                         break;
                     case BOTTOM:
-                        contentAnimator = AnimatorHelper.createBottomInAnim(view);
+                        if (getConfig().mIsAttachToKeyboard) {
+                            contentAnimator = AnimatorHelper.createAlphaInAnim(view);
+                        } else{
+                            contentAnimator = AnimatorHelper.createBottomInAnim(view);
+                        }
                         break;
                     default:
                         contentAnimator = onCreateDefContentInAnimator(view);
@@ -210,7 +214,11 @@ public class DialogLayer extends DecorLayer {
                 } else if ((swipeDirection & SwipeLayout.Direction.RIGHT) != 0) {
                     contentAnimator = AnimatorHelper.createRightInAnim(view);
                 } else if ((swipeDirection & SwipeLayout.Direction.BOTTOM) != 0) {
-                    contentAnimator = AnimatorHelper.createBottomInAnim(view);
+                    if (getConfig().mIsAttachToKeyboard) {
+                        contentAnimator = AnimatorHelper.createAlphaInAnim(view);
+                    } else{
+                        contentAnimator = AnimatorHelper.createBottomInAnim(view);
+                    }
                 } else {
                     contentAnimator = onCreateDefContentInAnimator(view);
                 }
@@ -900,15 +908,21 @@ public class DialogLayer extends DecorLayer {
         return (DialogLayer) super.cancelableOnClickKeyBack(cancelable);
     }
 
+    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, @Nullable int... focusIds) {
+        return compatSoftInput(alignToContentOrFocus,false, focusIds);
+    }
+
     /**
      * 适配软键盘的弹出，布局自动上移
      * 在某几个View获取焦点时布局上移
      *
-     * @param alignToContentOrFocus true为对齐到contentView，false为对齐到focusView自身
+     * @param alignToContentOrFocus true 为对齐到contentView，false为对齐到focusView自身
+     * @param isAttachToKeyboard   true 让弹窗的底部和键盘无缝相连
      * @param focusIds             焦点View
      */
     @NonNull
-    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, @Nullable int... focusIds) {
+    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, boolean isAttachToKeyboard, @Nullable int... focusIds) {
+        getConfig().mIsAttachToKeyboard = isAttachToKeyboard;
         if (getConfig().mSoftInputMapping == null) {
             getConfig().mSoftInputMapping = new SparseBooleanArray(1);
         }
@@ -1042,6 +1056,8 @@ public class DialogLayer extends DecorLayer {
         protected SwipeTransformer mSwipeTransformer = null;
 
         protected SparseBooleanArray mSoftInputMapping = null;
+
+        protected boolean mIsAttachToKeyboard = false;
     }
 
     protected static class ListenerHolder extends DecorLayer.ListenerHolder {

--- a/anylayer/src/main/java/per/goweii/anylayer/dialog/DialogLayer.java
+++ b/anylayer/src/main/java/per/goweii/anylayer/dialog/DialogLayer.java
@@ -195,11 +195,7 @@ public class DialogLayer extends DecorLayer {
                         contentAnimator = AnimatorHelper.createTopInAnim(view);
                         break;
                     case BOTTOM:
-                        if (getConfig().mIsAttachToKeyboard) {
-                            contentAnimator = AnimatorHelper.createAlphaInAnim(view);
-                        } else{
-                            contentAnimator = AnimatorHelper.createBottomInAnim(view);
-                        }
+                        contentAnimator = AnimatorHelper.createBottomInAnim(view);
                         break;
                     default:
                         contentAnimator = onCreateDefContentInAnimator(view);
@@ -214,11 +210,7 @@ public class DialogLayer extends DecorLayer {
                 } else if ((swipeDirection & SwipeLayout.Direction.RIGHT) != 0) {
                     contentAnimator = AnimatorHelper.createRightInAnim(view);
                 } else if ((swipeDirection & SwipeLayout.Direction.BOTTOM) != 0) {
-                    if (getConfig().mIsAttachToKeyboard) {
-                        contentAnimator = AnimatorHelper.createAlphaInAnim(view);
-                    } else{
-                        contentAnimator = AnimatorHelper.createBottomInAnim(view);
-                    }
+                    contentAnimator = AnimatorHelper.createBottomInAnim(view);
                 } else {
                     contentAnimator = onCreateDefContentInAnimator(view);
                 }
@@ -908,21 +900,15 @@ public class DialogLayer extends DecorLayer {
         return (DialogLayer) super.cancelableOnClickKeyBack(cancelable);
     }
 
-    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, @Nullable int... focusIds) {
-        return compatSoftInput(alignToContentOrFocus,false, focusIds);
-    }
-
     /**
      * 适配软键盘的弹出，布局自动上移
      * 在某几个View获取焦点时布局上移
      *
-     * @param alignToContentOrFocus true 为对齐到contentView，false为对齐到focusView自身
-     * @param isAttachToKeyboard   true 让弹窗的底部和键盘无缝相连
+     * @param alignToContentOrFocus true为对齐到contentView，false为对齐到focusView自身
      * @param focusIds             焦点View
      */
     @NonNull
-    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, boolean isAttachToKeyboard, @Nullable int... focusIds) {
-        getConfig().mIsAttachToKeyboard = isAttachToKeyboard;
+    public DialogLayer compatSoftInput(boolean alignToContentOrFocus, @Nullable int... focusIds) {
         if (getConfig().mSoftInputMapping == null) {
             getConfig().mSoftInputMapping = new SparseBooleanArray(1);
         }
@@ -1056,8 +1042,6 @@ public class DialogLayer extends DecorLayer {
         protected SwipeTransformer mSwipeTransformer = null;
 
         protected SparseBooleanArray mSoftInputMapping = null;
-
-        protected boolean mIsAttachToKeyboard = false;
     }
 
     protected static class ListenerHolder extends DecorLayer.ListenerHolder {

--- a/anylayer/src/main/java/per/goweii/anylayer/utils/AnimatorHelper.java
+++ b/anylayer/src/main/java/per/goweii/anylayer/utils/AnimatorHelper.java
@@ -20,939 +20,939 @@ import java.util.List;
 
 public class AnimatorHelper {
 
-    public static final float ZOOM_PERCENT = 0.9F;
-    public static final float MOVE_PERCENT = 0.9F;
-    public static final float INTERPOLATOR_FACTOR_1 = 1.5F;
-    public static final float INTERPOLATOR_FACTOR_2 = 2.5F;
+  public static final float ZOOM_PERCENT = 0.9F;
+  public static final float MOVE_PERCENT = 0.9F;
+  public static final float INTERPOLATOR_FACTOR_1 = 1.5F;
+  public static final float INTERPOLATOR_FACTOR_2 = 2.5F;
 
-    @NonNull
-    private static TimeInterpolator createDefInterpolator(float factor) {
-        return new DecelerateInterpolator(factor);
+  @NonNull
+  private static TimeInterpolator createDefInterpolator(float factor) {
+    return new DecelerateInterpolator(factor);
+  }
+
+  @NonNull
+  private static TimeInterpolator createDefInterpolator1() {
+    return createDefInterpolator(INTERPOLATOR_FACTOR_1);
+  }
+
+  @NonNull
+  private static TimeInterpolator createDefInterpolator2() {
+    return createDefInterpolator(INTERPOLATOR_FACTOR_2);
+  }
+
+  // AlphaIn
+
+  @NonNull
+  public static Animator createAlphaInAnim(@NonNull final View target) {
+    return createAlphaInAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createAlphaInAnim(@NonNull final View target,
+                                           @Nullable TimeInterpolator alphaInterpolator) {
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    return alpha;
+  }
+
+  // AlphaOut
+
+  @NonNull
+  public static Animator createAlphaOutAnim(@NonNull final View target) {
+    return createAlphaOutAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createAlphaOutAnim(@NonNull final View target,
+                                            @Nullable TimeInterpolator alphaInterpolator) {
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    return alpha;
+  }
+
+  // ZoomIn
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target) {
+    return createZoomInAnim(target, null);
+  }
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target,
+                                          @Nullable TimeInterpolator zoomInterpolator) {
+    return createZoomInAnim(target, 0.5F, 0.5F, zoomInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target,
+                                          float centerPercentX,
+                                          float centerPercentY) {
+    return createZoomInAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target,
+                                          float centerPercentX,
+                                          float centerPercentY,
+                                          @Nullable TimeInterpolator zoomInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createZoomInAnim(target, centerX, centerY, zoomInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target,
+                                          int centerX,
+                                          int centerY) {
+    return createZoomInAnim(target, centerX, centerY, null);
+  }
+
+  @NonNull
+  public static Animator createZoomInAnim(@NonNull final View target,
+                                          int centerX,
+                                          int centerY,
+                                          @Nullable TimeInterpolator zoomInterpolator) {
+    target.setPivotX(centerX);
+    target.setPivotY(centerY);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", 0, 1);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", 0, 1);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
     }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(scaleX, scaleY);
+    return set;
+  }
 
-    @NonNull
-    private static TimeInterpolator createDefInterpolator1() {
-        return createDefInterpolator(INTERPOLATOR_FACTOR_1);
+  // ZoomOut
+
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target) {
+    return createZoomOutAnim(target, null);
+  }
+
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target,
+                                           @Nullable TimeInterpolator zoomInterpolator) {
+    return createZoomOutAnim(target, 0.5F, 0.5F, zoomInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target,
+                                           float centerPercentX,
+                                           float centerPercentY) {
+    return createZoomOutAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target,
+                                           float centerPercentX,
+                                           float centerPercentY,
+                                           @Nullable TimeInterpolator zoomInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createZoomOutAnim(target, centerX, centerY, zoomInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target,
+                                           int centerX,
+                                           int centerY,
+                                           @Nullable TimeInterpolator zoomInterpolator) {
+    target.setPivotX(centerX);
+    target.setPivotY(centerY);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", target.getScaleX(), 0);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", target.getScaleY(), 0);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
     }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(scaleX, scaleY);
+    return set;
+  }
 
-    @NonNull
-    private static TimeInterpolator createDefInterpolator2() {
-        return createDefInterpolator(INTERPOLATOR_FACTOR_2);
+  @NonNull
+  public static Animator createZoomOutAnim(@NonNull final View target,
+                                           int centerX,
+                                           int centerY) {
+    return createZoomOutAnim(target, centerX, centerY, null);
+  }
+
+  // ZoomAlphaIn
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target) {
+    return createZoomAlphaInAnim(target, ZOOM_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               float fromScale) {
+    return createZoomAlphaInAnim(target, 0.5F, 0.5F, fromScale);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               float centerPercentX,
+                                               float centerPercentY) {
+    return createZoomAlphaInAnim(target, centerPercentX, centerPercentY, ZOOM_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               int centerX,
+                                               int centerY) {
+    return createZoomAlphaInAnim(target, centerX, centerY, ZOOM_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               float centerPercentX,
+                                               float centerPercentY,
+                                               float fromScale) {
+    return createZoomAlphaInAnim(target, centerPercentX, centerPercentY, fromScale,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               int centerX,
+                                               int centerY,
+                                               float fromScale) {
+    return createZoomAlphaInAnim(target, centerX, centerY, fromScale,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               float centerPercentX,
+                                               float centerPercentY,
+                                               float fromScale,
+                                               @Nullable TimeInterpolator zoomInterpolator,
+                                               @Nullable TimeInterpolator alphaInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createZoomAlphaInAnim(target, centerX, centerY, fromScale, zoomInterpolator, alphaInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaInAnim(@NonNull final View target,
+                                               int centerX,
+                                               int centerY,
+                                               float fromScale,
+                                               @Nullable TimeInterpolator zoomInterpolator,
+                                               @Nullable TimeInterpolator alphaInterpolator) {
+    target.setPivotX(centerX);
+    target.setPivotY(centerY);
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", fromScale, 1);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", fromScale, 1);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
     }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, scaleX, scaleY);
+    return set;
+  }
 
-    // AlphaIn
+  // ZoomAlphaOut
 
-    @NonNull
-    public static Animator createAlphaInAnim(@NonNull final View target) {
-        return createAlphaInAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target) {
+    return createZoomAlphaOutAnim(target, ZOOM_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createAlphaInAnim(@NonNull final View target,
-                                             @Nullable TimeInterpolator alphaInterpolator) {
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        return alpha;
-    }
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                float toScale) {
+    return createZoomAlphaOutAnim(target, 0.5F, 0.5F, toScale);
+  }
 
-    // AlphaOut
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                float centerPercentX,
+                                                float centerPercentY) {
+    return createZoomAlphaOutAnim(target, centerPercentX, centerPercentY, ZOOM_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createAlphaOutAnim(@NonNull final View target) {
-        return createAlphaOutAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                int centerX,
+                                                int centerY) {
+    return createZoomAlphaOutAnim(target, centerX, centerY, ZOOM_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createAlphaOutAnim(@NonNull final View target,
-                                              @Nullable TimeInterpolator alphaInterpolator) {
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        return alpha;
-    }
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                float centerPercentX,
+                                                float centerPercentY,
+                                                float toScale) {
+    return createZoomAlphaOutAnim(target, centerPercentX, centerPercentY, toScale,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    // ZoomIn
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                int centerX,
+                                                int centerY,
+                                                float toScale) {
+    return createZoomAlphaOutAnim(target, centerX, centerY, toScale,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target) {
-        return createZoomInAnim(target, null);
-    }
-
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target,
-                                            @Nullable TimeInterpolator zoomInterpolator) {
-        return createZoomInAnim(target, 0.5F, 0.5F, zoomInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target,
-                                            float centerPercentX,
-                                            float centerPercentY) {
-        return createZoomInAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target,
-                                            float centerPercentX,
-                                            float centerPercentY,
-                                            @Nullable TimeInterpolator zoomInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createZoomInAnim(target, centerX, centerY, zoomInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target,
-                                            int centerX,
-                                            int centerY) {
-        return createZoomInAnim(target, centerX, centerY, null);
-    }
-
-    @NonNull
-    public static Animator createZoomInAnim(@NonNull final View target,
-                                            int centerX,
-                                            int centerY,
-                                            @Nullable TimeInterpolator zoomInterpolator) {
-        target.setPivotX(centerX);
-        target.setPivotY(centerY);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", 0, 1);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", 0, 1);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(scaleX, scaleY);
-        return set;
-    }
-
-    // ZoomOut
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target) {
-        return createZoomOutAnim(target, null);
-    }
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target,
-                                             @Nullable TimeInterpolator zoomInterpolator) {
-        return createZoomOutAnim(target, 0.5F, 0.5F, zoomInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target,
-                                             float centerPercentX,
-                                             float centerPercentY) {
-        return createZoomOutAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target,
-                                             float centerPercentX,
-                                             float centerPercentY,
-                                             @Nullable TimeInterpolator zoomInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createZoomOutAnim(target, centerX, centerY, zoomInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target,
-                                             int centerX,
-                                             int centerY,
-                                             @Nullable TimeInterpolator zoomInterpolator) {
-        target.setPivotX(centerX);
-        target.setPivotY(centerY);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", target.getScaleX(), 0);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", target.getScaleY(), 0);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(scaleX, scaleY);
-        return set;
-    }
-
-    @NonNull
-    public static Animator createZoomOutAnim(@NonNull final View target,
-                                             int centerX,
-                                             int centerY) {
-        return createZoomOutAnim(target, centerX, centerY, null);
-    }
-
-    // ZoomAlphaIn
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target) {
-        return createZoomAlphaInAnim(target, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 float fromScale) {
-        return createZoomAlphaInAnim(target, 0.5F, 0.5F, fromScale);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 float centerPercentX,
-                                                 float centerPercentY) {
-        return createZoomAlphaInAnim(target, centerPercentX, centerPercentY, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 int centerX,
-                                                 int centerY) {
-        return createZoomAlphaInAnim(target, centerX, centerY, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 float centerPercentX,
-                                                 float centerPercentY,
-                                                 float fromScale) {
-        return createZoomAlphaInAnim(target, centerPercentX, centerPercentY, fromScale,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 int centerX,
-                                                 int centerY,
-                                                 float fromScale) {
-        return createZoomAlphaInAnim(target, centerX, centerY, fromScale,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 float centerPercentX,
-                                                 float centerPercentY,
-                                                 float fromScale,
-                                                 @Nullable TimeInterpolator zoomInterpolator,
-                                                 @Nullable TimeInterpolator alphaInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createZoomAlphaInAnim(target, centerX, centerY, fromScale, zoomInterpolator, alphaInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaInAnim(@NonNull final View target,
-                                                 int centerX,
-                                                 int centerY,
-                                                 float fromScale,
-                                                 @Nullable TimeInterpolator zoomInterpolator,
-                                                 @Nullable TimeInterpolator alphaInterpolator) {
-        target.setPivotX(centerX);
-        target.setPivotY(centerY);
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", fromScale, 1);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", fromScale, 1);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, scaleX, scaleY);
-        return set;
-    }
-
-    // ZoomAlphaOut
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target) {
-        return createZoomAlphaOutAnim(target, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  float toScale) {
-        return createZoomAlphaOutAnim(target, 0.5F, 0.5F, toScale);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  float centerPercentX,
-                                                  float centerPercentY) {
-        return createZoomAlphaOutAnim(target, centerPercentX, centerPercentY, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  int centerX,
-                                                  int centerY) {
-        return createZoomAlphaOutAnim(target, centerX, centerY, ZOOM_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  float centerPercentX,
-                                                  float centerPercentY,
-                                                  float toScale) {
-        return createZoomAlphaOutAnim(target, centerPercentX, centerPercentY, toScale,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  int centerX,
-                                                  int centerY,
-                                                  float toScale) {
-        return createZoomAlphaOutAnim(target, centerX, centerY, toScale,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  float centerPercentX,
-                                                  float centerPercentY,
-                                                  float toScale,
-                                                  @Nullable TimeInterpolator zoomInterpolator,
-                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createZoomAlphaOutAnim(target, centerX, centerY, toScale, zoomInterpolator, alphaInterpolator);
-    }
-
-    @NonNull
-    public static Animator createZoomAlphaOutAnim(@NonNull final View target,
-                                                  int centerX,
-                                                  int centerY,
-                                                  float toScale,
-                                                  @Nullable TimeInterpolator zoomInterpolator,
-                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        target.setPivotX(centerX);
-        target.setPivotY(centerY);
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", target.getScaleX(), toScale);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", target.getScaleY(), toScale);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, scaleX, scaleY);
-        return set;
-    }
-
-    // TopIn
-
-    @NonNull
-    public static Animator createTopInAnim(@NonNull final View target) {
-        return createTopInAnim(target, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createTopInAnim(@NonNull final View target,
-                                           @Nullable TimeInterpolator topInterpolator) {
-        ObjectAnimator top = ObjectAnimator.ofFloat(target, "translationY", -target.getBottom(), 0);
-        if (topInterpolator != null) top.setInterpolator(topInterpolator);
-        return top;
-    }
-
-    // TopOut
-
-    @NonNull
-    public static Animator createTopOutAnim(@NonNull final View target) {
-        return createTopOutAnim(target, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createTopOutAnim(@NonNull final View target, TimeInterpolator topInterpolator) {
-        ObjectAnimator top = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), -target.getBottom());
-        if (topInterpolator != null) top.setInterpolator(topInterpolator);
-        return top;
-    }
-
-    // TopAlphaIn
-
-    @NonNull
-    public static Animator createTopAlphaInAnim(@NonNull final View target) {
-        return createTopAlphaInAnim(target, 1 - MOVE_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createTopAlphaInAnim(@NonNull final View target,
-                                                float percentTargetHeight) {
-        return createTopAlphaInAnim(target, percentTargetHeight,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createTopAlphaInAnim(@NonNull final View target,
-                                                float percentTargetHeight,
-                                                @Nullable TimeInterpolator yInterpolator,
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                float centerPercentX,
+                                                float centerPercentY,
+                                                float toScale,
+                                                @Nullable TimeInterpolator zoomInterpolator,
                                                 @Nullable TimeInterpolator alphaInterpolator) {
-        float y = percentTargetHeight * target.getMeasuredHeight();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", -y, 0);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationY);
-        return set;
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createZoomAlphaOutAnim(target, centerX, centerY, toScale, zoomInterpolator, alphaInterpolator);
+  }
+
+  @NonNull
+  public static Animator createZoomAlphaOutAnim(@NonNull final View target,
+                                                int centerX,
+                                                int centerY,
+                                                float toScale,
+                                                @Nullable TimeInterpolator zoomInterpolator,
+                                                @Nullable TimeInterpolator alphaInterpolator) {
+    target.setPivotX(centerX);
+    target.setPivotY(centerY);
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(target, "scaleX", target.getScaleX(), toScale);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(target, "scaleY", target.getScaleY(), toScale);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
     }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, scaleX, scaleY);
+    return set;
+  }
 
-    // TopAlphaOut
+  // TopIn
 
-    @NonNull
-    public static Animator createTopAlphaOutAnim(@NonNull final View target) {
-        return createTopAlphaOutAnim(target, 1 - MOVE_PERCENT);
-    }
+  @NonNull
+  public static Animator createTopInAnim(@NonNull final View target) {
+    return createTopInAnim(target, createDefInterpolator1());
+  }
 
-    @NonNull
-    public static Animator createTopAlphaOutAnim(@NonNull final View target,
+  @NonNull
+  public static Animator createTopInAnim(@NonNull final View target,
+                                         @Nullable TimeInterpolator topInterpolator) {
+    ObjectAnimator top = ObjectAnimator.ofFloat(target, "translationY", -target.getBottom(), 0);
+    if (topInterpolator != null) top.setInterpolator(topInterpolator);
+    return top;
+  }
+
+  // TopOut
+
+  @NonNull
+  public static Animator createTopOutAnim(@NonNull final View target) {
+    return createTopOutAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createTopOutAnim(@NonNull final View target, TimeInterpolator topInterpolator) {
+    ObjectAnimator top = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), -target.getBottom());
+    if (topInterpolator != null) top.setInterpolator(topInterpolator);
+    return top;
+  }
+
+  // TopAlphaIn
+
+  @NonNull
+  public static Animator createTopAlphaInAnim(@NonNull final View target) {
+    return createTopAlphaInAnim(target, 1 - MOVE_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createTopAlphaInAnim(@NonNull final View target,
+                                              float percentTargetHeight) {
+    return createTopAlphaInAnim(target, percentTargetHeight,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createTopAlphaInAnim(@NonNull final View target,
+                                              float percentTargetHeight,
+                                              @Nullable TimeInterpolator yInterpolator,
+                                              @Nullable TimeInterpolator alphaInterpolator) {
+    float y = percentTargetHeight * target.getMeasuredHeight();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", -y, 0);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationY);
+    return set;
+  }
+
+  // TopAlphaOut
+
+  @NonNull
+  public static Animator createTopAlphaOutAnim(@NonNull final View target) {
+    return createTopAlphaOutAnim(target, 1 - MOVE_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createTopAlphaOutAnim(@NonNull final View target,
+                                               float percentTargetHeight) {
+    return createTopAlphaOutAnim(target, percentTargetHeight,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createTopAlphaOutAnim(@NonNull final View target,
+                                               float percentTargetHeight,
+                                               @Nullable TimeInterpolator yInterpolator,
+                                               @Nullable TimeInterpolator alphaInterpolator) {
+    float y = percentTargetHeight * target.getMeasuredHeight();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), -y);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationY);
+    return set;
+  }
+
+  // BottomIn
+
+  @NonNull
+  public static Animator createBottomInAnim(@NonNull final View target) {
+    return createBottomInAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createBottomInAnim(@NonNull final View target,
+                                            @Nullable TimeInterpolator yInterpolator) {
+    float y = ((ViewGroup) target.getParent()).getMeasuredHeight() - target.getTop();
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", y, 0);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    return translationY;
+  }
+
+  // BottomAlphaIn
+
+  @NonNull
+  public static Animator createBottomAlphaInAnim(@NonNull final View target) {
+    return createBottomAlphaInAnim(target, 1 - MOVE_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createBottomAlphaInAnim(@NonNull final View target,
                                                  float percentTargetHeight) {
-        return createTopAlphaOutAnim(target, percentTargetHeight,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
+    return createBottomAlphaInAnim(target, percentTargetHeight,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    @NonNull
-    public static Animator createTopAlphaOutAnim(@NonNull final View target,
+  @NonNull
+  public static Animator createBottomAlphaInAnim(@NonNull final View target,
                                                  float percentTargetHeight,
                                                  @Nullable TimeInterpolator yInterpolator,
                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        float y = percentTargetHeight * target.getMeasuredHeight();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), -y);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationY);
-        return set;
-    }
+    float y = percentTargetHeight * target.getMeasuredHeight();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", y, 0);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationY);
+    return set;
+  }
 
-    // BottomIn
+  // BottomOut
 
-    @NonNull
-    public static Animator createBottomInAnim(@NonNull final View target) {
-        return createBottomInAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createBottomOutAnim(@NonNull final View target) {
+    return createBottomOutAnim(target, createDefInterpolator1());
+  }
 
-    @NonNull
-    public static Animator createBottomInAnim(@NonNull final View target,
-                                              @Nullable TimeInterpolator yInterpolator) {
-        float y = ((ViewGroup) target.getParent()).getMeasuredHeight() - target.getTop();
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", y, 0);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        return translationY;
-    }
+  @NonNull
+  public static Animator createBottomOutAnim(@NonNull final View target,
+                                             @Nullable TimeInterpolator yInterpolator) {
+    float y = ((ViewGroup) target.getParent()).getMeasuredHeight() - target.getTop();
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), y);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    return translationY;
+  }
 
-    // BottomAlphaIn
+  // BottomAlphaOut
 
-    @NonNull
-    public static Animator createBottomAlphaInAnim(@NonNull final View target) {
-        return createBottomAlphaInAnim(target, 1 - MOVE_PERCENT);
-    }
+  @NonNull
+  public static Animator createBottomAlphaOutAnim(@NonNull final View target) {
+    return createBottomAlphaOutAnim(target, 1 - MOVE_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createBottomAlphaInAnim(@NonNull final View target,
-                                                   float percentTargetHeight) {
-        return createBottomAlphaInAnim(target, percentTargetHeight,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
+  @NonNull
+  public static Animator createBottomAlphaOutAnim(@NonNull final View target,
+                                                  float percentTargetHeight) {
+    return createBottomAlphaOutAnim(target, percentTargetHeight,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    @NonNull
-    public static Animator createBottomAlphaInAnim(@NonNull final View target,
-                                                   float percentTargetHeight,
-                                                   @Nullable TimeInterpolator yInterpolator,
-                                                   @Nullable TimeInterpolator alphaInterpolator) {
-        float y = percentTargetHeight * target.getMeasuredHeight();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", y, 0);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationY);
-        return set;
-    }
+  @NonNull
+  public static Animator createBottomAlphaOutAnim(@NonNull final View target,
+                                                  float percentTargetHeight,
+                                                  @Nullable TimeInterpolator yInterpolator,
+                                                  @Nullable TimeInterpolator alphaInterpolator) {
+    float y = percentTargetHeight * target.getMeasuredHeight();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), y);
+    if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationY);
+    return set;
+  }
 
-    // BottomOut
+  // LeftIn
 
-    @NonNull
-    public static Animator createBottomOutAnim(@NonNull final View target) {
-        return createBottomOutAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createLeftInAnim(@NonNull final View target) {
+    return createLeftInAnim(target, createDefInterpolator1());
+  }
 
-    @NonNull
-    public static Animator createBottomOutAnim(@NonNull final View target,
-                                               @Nullable TimeInterpolator yInterpolator) {
-        float y = ((ViewGroup) target.getParent()).getMeasuredHeight() - target.getTop();
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), y);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        return translationY;
-    }
+  @NonNull
+  public static Animator createLeftInAnim(@NonNull final View target,
+                                          @Nullable TimeInterpolator xInterpolator) {
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", -target.getRight(), 0);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    return translationX;
+  }
 
-    // BottomAlphaOut
+  // LeftOut
 
-    @NonNull
-    public static Animator createBottomAlphaOutAnim(@NonNull final View target) {
-        return createBottomAlphaOutAnim(target, 1 - MOVE_PERCENT);
-    }
+  @NonNull
+  public static Animator createLeftOutAnim(@NonNull final View target) {
+    return createLeftOutAnim(target, createDefInterpolator1());
+  }
 
-    @NonNull
-    public static Animator createBottomAlphaOutAnim(@NonNull final View target,
-                                                    float percentTargetHeight) {
-        return createBottomAlphaOutAnim(target, percentTargetHeight,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
+  @NonNull
+  public static Animator createLeftOutAnim(@NonNull final View target,
+                                           @Nullable TimeInterpolator xInterpolator) {
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), -target.getRight());
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    return translationX;
+  }
 
-    @NonNull
-    public static Animator createBottomAlphaOutAnim(@NonNull final View target,
-                                                    float percentTargetHeight,
-                                                    @Nullable TimeInterpolator yInterpolator,
-                                                    @Nullable TimeInterpolator alphaInterpolator) {
-        float y = percentTargetHeight * target.getMeasuredHeight();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationY = ObjectAnimator.ofFloat(target, "translationY", target.getTranslationY(), y);
-        if (yInterpolator != null) translationY.setInterpolator(yInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationY);
-        return set;
-    }
+  // LeftAlphaIn
 
-    // LeftIn
+  @NonNull
+  public static Animator createLeftAlphaInAnim(@NonNull final View target) {
+    return createLeftAlphaInAnim(target, 1 - MOVE_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createLeftInAnim(@NonNull final View target) {
-        return createLeftInAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createLeftAlphaInAnim(@NonNull final View target,
+                                               float percentTargetWidth) {
+    return createLeftAlphaInAnim(target, percentTargetWidth,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    @NonNull
-    public static Animator createLeftInAnim(@NonNull final View target,
+  @NonNull
+  public static Animator createLeftAlphaInAnim(@NonNull final View target,
+                                               float percentTargetWidth,
+                                               @Nullable TimeInterpolator xInterpolator,
+                                               @Nullable TimeInterpolator alphaInterpolator) {
+    float x = percentTargetWidth * target.getMeasuredWidth();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", -x, 0);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationX);
+    return set;
+  }
+
+  // LeftAlphaOut
+
+  @NonNull
+  public static Animator createLeftAlphaOutAnim(@NonNull final View target) {
+    return createLeftAlphaOutAnim(target, 1 - MOVE_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createLeftAlphaOutAnim(@NonNull final View target,
+                                                float percentTargetWidth) {
+    return createLeftAlphaOutAnim(target, percentTargetWidth,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createLeftAlphaOutAnim(@NonNull final View target,
+                                                float percentTargetWidth,
+                                                @Nullable TimeInterpolator xInterpolator,
+                                                @Nullable TimeInterpolator alphaInterpolator) {
+    float x = percentTargetWidth * target.getMeasuredWidth();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), -x);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationX);
+    return set;
+  }
+
+  // RightIn
+
+  @NonNull
+  public static Animator createRightInAnim(@NonNull final View target) {
+    return createRightInAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createRightInAnim(@NonNull final View target,
+                                           @Nullable TimeInterpolator xInterpolator) {
+    float x = ((ViewGroup) target.getParent()).getMeasuredWidth() - target.getLeft();
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", x, 0);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    return translationX;
+  }
+
+  // RightOut
+
+  @NonNull
+  public static Animator createRightOutAnim(@NonNull final View target) {
+    return createRightOutAnim(target, createDefInterpolator1());
+  }
+
+  @NonNull
+  public static Animator createRightOutAnim(@NonNull final View target,
                                             @Nullable TimeInterpolator xInterpolator) {
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", -target.getRight(), 0);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        return translationX;
-    }
+    float x = ((ViewGroup) target.getParent()).getMeasuredWidth() - target.getLeft();
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), x);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    return translationX;
+  }
 
-    // LeftOut
+  // RightAlphaIn
 
-    @NonNull
-    public static Animator createLeftOutAnim(@NonNull final View target) {
-        return createLeftOutAnim(target, createDefInterpolator1());
-    }
+  @NonNull
+  public static Animator createRightAlphaInAnim(@NonNull final View target) {
+    return createRightAlphaInAnim(target, 1 - MOVE_PERCENT);
+  }
 
-    @NonNull
-    public static Animator createLeftOutAnim(@NonNull final View target,
-                                             @Nullable TimeInterpolator xInterpolator) {
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), -target.getRight());
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        return translationX;
-    }
+  @NonNull
+  public static Animator createRightAlphaInAnim(@NonNull final View target,
+                                                float percentTargetWidth) {
+    return createRightAlphaInAnim(target, percentTargetWidth,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    // LeftAlphaIn
+  @NonNull
+  public static Animator createRightAlphaInAnim(@NonNull final View target,
+                                                float percentTargetWidth,
+                                                @Nullable TimeInterpolator xInterpolator,
+                                                @Nullable TimeInterpolator alphaInterpolator) {
+    float x = percentTargetWidth * target.getMeasuredWidth();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", x, 0);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationX);
+    return set;
+  }
 
-    @NonNull
-    public static Animator createLeftAlphaInAnim(@NonNull final View target) {
-        return createLeftAlphaInAnim(target, 1 - MOVE_PERCENT);
-    }
+  // RightAlphaOut
 
-    @NonNull
-    public static Animator createLeftAlphaInAnim(@NonNull final View target,
+  @NonNull
+  public static Animator createRightAlphaOutAnim(@NonNull final View target) {
+    return createRightAlphaOutAnim(target, 1 - MOVE_PERCENT);
+  }
+
+  @NonNull
+  public static Animator createRightAlphaOutAnim(@NonNull final View target,
                                                  float percentTargetWidth) {
-        return createLeftAlphaInAnim(target, percentTargetWidth,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
+    return createRightAlphaOutAnim(target, percentTargetWidth,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
 
-    @NonNull
-    public static Animator createLeftAlphaInAnim(@NonNull final View target,
+  @NonNull
+  public static Animator createRightAlphaOutAnim(@NonNull final View target,
                                                  float percentTargetWidth,
                                                  @Nullable TimeInterpolator xInterpolator,
                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        float x = percentTargetWidth * target.getMeasuredWidth();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", -x, 0);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationX);
-        return set;
-    }
+    float x = percentTargetWidth * target.getMeasuredWidth();
+    ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
+    if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
+    ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), x);
+    if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(alpha, translationX);
+    return set;
+  }
 
-    // LeftAlphaOut
+  // CircularRevealIn
 
-    @NonNull
-    public static Animator createLeftAlphaOutAnim(@NonNull final View target) {
-        return createLeftAlphaOutAnim(target, 1 - MOVE_PERCENT);
-    }
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealInAnim(@NonNull final View target) {
+    return createCircularRevealInAnim(target, 0.5F, 0.5F);
+  }
 
-    @NonNull
-    public static Animator createLeftAlphaOutAnim(@NonNull final View target,
-                                                  float percentTargetWidth) {
-        return createLeftAlphaOutAnim(target, percentTargetWidth,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createLeftAlphaOutAnim(@NonNull final View target,
-                                                  float percentTargetWidth,
-                                                  @Nullable TimeInterpolator xInterpolator,
-                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        float x = percentTargetWidth * target.getMeasuredWidth();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), -x);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationX);
-        return set;
-    }
-
-    // RightIn
-
-    @NonNull
-    public static Animator createRightInAnim(@NonNull final View target) {
-        return createRightInAnim(target, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createRightInAnim(@NonNull final View target,
-                                             @Nullable TimeInterpolator xInterpolator) {
-        float x = ((ViewGroup) target.getParent()).getMeasuredWidth() - target.getLeft();
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", x, 0);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        return translationX;
-    }
-
-    // RightOut
-
-    @NonNull
-    public static Animator createRightOutAnim(@NonNull final View target) {
-        return createRightOutAnim(target, createDefInterpolator1());
-    }
-
-    @NonNull
-    public static Animator createRightOutAnim(@NonNull final View target,
-                                              @Nullable TimeInterpolator xInterpolator) {
-        float x = ((ViewGroup) target.getParent()).getMeasuredWidth() - target.getLeft();
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), x);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        return translationX;
-    }
-
-    // RightAlphaIn
-
-    @NonNull
-    public static Animator createRightAlphaInAnim(@NonNull final View target) {
-        return createRightAlphaInAnim(target, 1 - MOVE_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createRightAlphaInAnim(@NonNull final View target,
-                                                  float percentTargetWidth) {
-        return createRightAlphaInAnim(target, percentTargetWidth,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createRightAlphaInAnim(@NonNull final View target,
-                                                  float percentTargetWidth,
-                                                  @Nullable TimeInterpolator xInterpolator,
-                                                  @Nullable TimeInterpolator alphaInterpolator) {
-        float x = percentTargetWidth * target.getMeasuredWidth();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", 0, 1);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", x, 0);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationX);
-        return set;
-    }
-
-    // RightAlphaOut
-
-    @NonNull
-    public static Animator createRightAlphaOutAnim(@NonNull final View target) {
-        return createRightAlphaOutAnim(target, 1 - MOVE_PERCENT);
-    }
-
-    @NonNull
-    public static Animator createRightAlphaOutAnim(@NonNull final View target,
-                                                   float percentTargetWidth) {
-        return createRightAlphaOutAnim(target, percentTargetWidth,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createRightAlphaOutAnim(@NonNull final View target,
-                                                   float percentTargetWidth,
-                                                   @Nullable TimeInterpolator xInterpolator,
-                                                   @Nullable TimeInterpolator alphaInterpolator) {
-        float x = percentTargetWidth * target.getMeasuredWidth();
-        ObjectAnimator alpha = ObjectAnimator.ofFloat(target, "alpha", target.getAlpha(), 0);
-        if (alphaInterpolator != null) alpha.setInterpolator(alphaInterpolator);
-        ObjectAnimator translationX = ObjectAnimator.ofFloat(target, "translationX", target.getTranslationX(), x);
-        if (xInterpolator != null) translationX.setInterpolator(xInterpolator);
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(alpha, translationX);
-        return set;
-    }
-
-    // CircularRevealIn
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealInAnim(@NonNull final View target) {
-        return createCircularRevealInAnim(target, 0.5F, 0.5F);
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealInAnim(@NonNull final View target,
-                                                      float centerPercentX,
-                                                      float centerPercentY) {
-        return createCircularRevealInAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealInAnim(@NonNull final View target,
-                                                      int centerX,
-                                                      int centerY) {
-        return createCircularRevealInAnim(target, centerX, centerY, createDefInterpolator1());
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealInAnim(@NonNull final View target,
-                                                      float centerPercentX,
-                                                      float centerPercentY,
-                                                      @Nullable TimeInterpolator timeInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createCircularRevealInAnim(target, centerX, centerY, timeInterpolator);
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealInAnim(@NonNull final View target,
-                                                      int centerX,
-                                                      int centerY,
-                                                      @Nullable TimeInterpolator timeInterpolator) {
-        int x = target.getMeasuredWidth();
-        int y = target.getMeasuredHeight();
-        int r = (int) Math.sqrt(Math.pow(Math.max(centerX, x - centerX), 2) + Math.pow(Math.max(centerY, y - centerY), 2));
-        Animator animator = ViewAnimationUtils.createCircularReveal(target, centerX, centerY, 0, r);
-        if (timeInterpolator != null) animator.setInterpolator(timeInterpolator);
-        return animator;
-    }
-
-    // CircularRevealOut
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealOutAnim(@NonNull final View target) {
-        return createCircularRevealOutAnim(target, 0.5F, 0.5F);
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealOutAnim(@NonNull final View target,
-                                                       float centerPercentX,
-                                                       float centerPercentY) {
-        return createCircularRevealOutAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealOutAnim(@NonNull final View target,
-                                                       int centerX,
-                                                       int centerY) {
-        return createCircularRevealOutAnim(target, centerX, centerY, createDefInterpolator1());
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealOutAnim(@NonNull final View target,
-                                                       float centerPercentX,
-                                                       float centerPercentY,
-                                                       @Nullable TimeInterpolator timeInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createCircularRevealOutAnim(target, centerX, centerY, timeInterpolator);
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    @NonNull
-    public static Animator createCircularRevealOutAnim(@NonNull final View target,
-                                                       int centerX,
-                                                       int centerY,
-                                                       @Nullable TimeInterpolator timeInterpolator) {
-        int x = target.getMeasuredWidth();
-        int y = target.getMeasuredHeight();
-        int r = (int) Math.sqrt(Math.pow(Math.max(centerX, x - centerX), 2) + Math.pow(Math.max(centerY, y - centerY), 2));
-        Animator animator = ViewAnimationUtils.createCircularReveal(target, centerX, centerY, r, 0);
-        if (timeInterpolator != null) animator.setInterpolator(timeInterpolator);
-        return animator;
-    }
-
-    // DelayedZoomIn
-
-    @NonNull
-    public static Animator createDelayedZoomInAnim(@NonNull final View target) {
-        return createDelayedZoomInAnim(target, 0.5F, 0.5F);
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomInAnim(@NonNull final View target,
-                                                   int centerX,
-                                                   int centerY) {
-        return createDelayedZoomInAnim(target, centerX, centerY,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomInAnim(@NonNull final View target,
-                                                   float centerPercentX,
-                                                   float centerPercentY) {
-        return createDelayedZoomInAnim(target, centerPercentX, centerPercentY,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomInAnim(@NonNull final View target,
-                                                   float centerPercentX,
-                                                   float centerPercentY,
-                                                   @Nullable TimeInterpolator zoomInterpolator,
-                                                   @Nullable TimeInterpolator alphaInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createDelayedZoomInAnim(target, centerX, centerY, zoomInterpolator, alphaInterpolator);
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomInAnim(@NonNull final View target,
-                                                   int centerX,
-                                                   int centerY,
-                                                   @Nullable TimeInterpolator zoomInterpolator,
-                                                   @Nullable TimeInterpolator alphaInterpolator) {
-        if (!(target instanceof ViewGroup)) {
-            return createZoomInAnim(target, centerX, centerY);
-        }
-        ViewGroup targetGroup = (ViewGroup) target;
-        for (int i = 0; i < targetGroup.getChildCount(); i++) {
-            View targetChild = targetGroup.getChildAt(i);
-            targetChild.setAlpha(0);
-        }
-        targetGroup.setPivotX(centerX);
-        targetGroup.setPivotY(centerY);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(targetGroup, "scaleX", 0, 1);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(targetGroup, "scaleY", 0, 1);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(scaleX, scaleY);
-        scaleX.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-            private boolean isChildAnimStart = false;
-
-            @Override
-            public void onAnimationUpdate(ValueAnimator animation) {
-                float f = animation.getAnimatedFraction();
-                if (!isChildAnimStart && f > 0.618F) {
-                    isChildAnimStart = true;
-                    final List<Animator> childAnimators = new ArrayList<>(targetGroup.getChildCount());
-                    for (int i = 0; i < targetGroup.getChildCount(); i++) {
-                        View targetChild = targetGroup.getChildAt(i);
-                        ObjectAnimator alphaChild = ObjectAnimator.ofFloat(targetChild, "alpha", 0, 1);
-                        if (alphaInterpolator != null)
-                            alphaChild.setInterpolator(alphaInterpolator);
-                        alphaChild.setStartDelay(18 * i);
-                        alphaChild.setDuration(50);
-                        childAnimators.add(alphaChild);
-                    }
-                    AnimatorSet set = new AnimatorSet();
-                    set.playTogether(childAnimators);
-                    set.start();
-                }
-            }
-        });
-        return set;
-    }
-
-    // DelayedZoomOut
-
-    @NonNull
-    public static Animator createDelayedZoomOutAnim(@NonNull final View target) {
-        return createDelayedZoomOutAnim(target, 0.5F, 0.5F);
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomOutAnim(@NonNull final View target,
-                                                    int centerX,
-                                                    int centerY) {
-        return createDelayedZoomOutAnim(target, centerX, centerY,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
-
-    @NonNull
-    public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealInAnim(@NonNull final View target,
                                                     float centerPercentX,
                                                     float centerPercentY) {
-        return createDelayedZoomOutAnim(target, centerPercentX, centerPercentY,
-                createDefInterpolator1(), createDefInterpolator2());
-    }
+    return createCircularRevealInAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
+  }
 
-    @NonNull
-    public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealInAnim(@NonNull final View target,
+                                                    int centerX,
+                                                    int centerY) {
+    return createCircularRevealInAnim(target, centerX, centerY, createDefInterpolator1());
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealInAnim(@NonNull final View target,
                                                     float centerPercentX,
                                                     float centerPercentY,
-                                                    @Nullable TimeInterpolator zoomInterpolator,
-                                                    @Nullable TimeInterpolator alphaInterpolator) {
-        int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
-        int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
-        return createDelayedZoomOutAnim(target, centerX, centerY, zoomInterpolator, alphaInterpolator);
-    }
+                                                    @Nullable TimeInterpolator timeInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createCircularRevealInAnim(target, centerX, centerY, timeInterpolator);
+  }
 
-    @NonNull
-    public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealInAnim(@NonNull final View target,
                                                     int centerX,
                                                     int centerY,
-                                                    @Nullable TimeInterpolator zoomInterpolator,
-                                                    @Nullable TimeInterpolator alphaInterpolator) {
-        if (!(target instanceof ViewGroup)) {
-            return createZoomInAnim(target, centerX, centerY);
-        }
-        ViewGroup targetGroup = (ViewGroup) target;
-        targetGroup.setPivotX(centerX);
-        targetGroup.setPivotY(centerY);
-        ObjectAnimator scaleX = ObjectAnimator.ofFloat(targetGroup, "scaleX", targetGroup.getScaleX(), 0);
-        ObjectAnimator scaleY = ObjectAnimator.ofFloat(targetGroup, "scaleY", targetGroup.getScaleY(), 0);
-        if (zoomInterpolator != null) {
-            scaleX.setInterpolator(zoomInterpolator);
-            scaleY.setInterpolator(zoomInterpolator);
-        }
-        AnimatorSet set = new AnimatorSet();
-        set.playTogether(scaleX, scaleY);
-        scaleX.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-            private boolean isChildAnimStart = false;
+                                                    @Nullable TimeInterpolator timeInterpolator) {
+    int x = target.getMeasuredWidth();
+    int y = target.getMeasuredHeight();
+    int r = (int) Math.sqrt(Math.pow(Math.max(centerX, x - centerX), 2) + Math.pow(Math.max(centerY, y - centerY), 2));
+    Animator animator = ViewAnimationUtils.createCircularReveal(target, centerX, centerY, 0, r);
+    if (timeInterpolator != null) animator.setInterpolator(timeInterpolator);
+    return animator;
+  }
 
-            @Override
-            public void onAnimationUpdate(ValueAnimator animation) {
-                if (!isChildAnimStart) {
-                    isChildAnimStart = true;
-                    final List<Animator> childAnimators = new ArrayList<>(targetGroup.getChildCount());
-                    for (int i = targetGroup.getChildCount() - 1; i >= 0; i--) {
-                        View targetChild = targetGroup.getChildAt(i);
-                        ObjectAnimator alphaChild = ObjectAnimator.ofFloat(targetChild, "alpha", targetChild.getAlpha(), 0);
-                        if (alphaInterpolator != null)
-                            alphaChild.setInterpolator(alphaInterpolator);
-                        alphaChild.setStartDelay(18 * (targetGroup.getChildCount() - 1 - i));
-                        alphaChild.setDuration(50);
-                        childAnimators.add(alphaChild);
-                    }
-                    AnimatorSet set = new AnimatorSet();
-                    set.playTogether(childAnimators);
-                    set.start();
-                }
-            }
-        });
-        return set;
+  // CircularRevealOut
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealOutAnim(@NonNull final View target) {
+    return createCircularRevealOutAnim(target, 0.5F, 0.5F);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealOutAnim(@NonNull final View target,
+                                                     float centerPercentX,
+                                                     float centerPercentY) {
+    return createCircularRevealOutAnim(target, centerPercentX, centerPercentY, createDefInterpolator1());
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealOutAnim(@NonNull final View target,
+                                                     int centerX,
+                                                     int centerY) {
+    return createCircularRevealOutAnim(target, centerX, centerY, createDefInterpolator1());
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealOutAnim(@NonNull final View target,
+                                                     float centerPercentX,
+                                                     float centerPercentY,
+                                                     @Nullable TimeInterpolator timeInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createCircularRevealOutAnim(target, centerX, centerY, timeInterpolator);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  @NonNull
+  public static Animator createCircularRevealOutAnim(@NonNull final View target,
+                                                     int centerX,
+                                                     int centerY,
+                                                     @Nullable TimeInterpolator timeInterpolator) {
+    int x = target.getMeasuredWidth();
+    int y = target.getMeasuredHeight();
+    int r = (int) Math.sqrt(Math.pow(Math.max(centerX, x - centerX), 2) + Math.pow(Math.max(centerY, y - centerY), 2));
+    Animator animator = ViewAnimationUtils.createCircularReveal(target, centerX, centerY, r, 0);
+    if (timeInterpolator != null) animator.setInterpolator(timeInterpolator);
+    return animator;
+  }
+
+  // DelayedZoomIn
+
+  @NonNull
+  public static Animator createDelayedZoomInAnim(@NonNull final View target) {
+    return createDelayedZoomInAnim(target, 0.5F, 0.5F);
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomInAnim(@NonNull final View target,
+                                                 int centerX,
+                                                 int centerY) {
+    return createDelayedZoomInAnim(target, centerX, centerY,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomInAnim(@NonNull final View target,
+                                                 float centerPercentX,
+                                                 float centerPercentY) {
+    return createDelayedZoomInAnim(target, centerPercentX, centerPercentY,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomInAnim(@NonNull final View target,
+                                                 float centerPercentX,
+                                                 float centerPercentY,
+                                                 @Nullable TimeInterpolator zoomInterpolator,
+                                                 @Nullable TimeInterpolator alphaInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createDelayedZoomInAnim(target, centerX, centerY, zoomInterpolator, alphaInterpolator);
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomInAnim(@NonNull final View target,
+                                                 int centerX,
+                                                 int centerY,
+                                                 @Nullable TimeInterpolator zoomInterpolator,
+                                                 @Nullable TimeInterpolator alphaInterpolator) {
+    if (!(target instanceof ViewGroup)) {
+      return createZoomInAnim(target, centerX, centerY);
     }
+    ViewGroup targetGroup = (ViewGroup) target;
+    for (int i = 0; i < targetGroup.getChildCount(); i++) {
+      View targetChild = targetGroup.getChildAt(i);
+      targetChild.setAlpha(0);
+    }
+    targetGroup.setPivotX(centerX);
+    targetGroup.setPivotY(centerY);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(targetGroup, "scaleX", 0, 1);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(targetGroup, "scaleY", 0, 1);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
+    }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(scaleX, scaleY);
+    scaleX.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      private boolean isChildAnimStart = false;
+
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        float f = animation.getAnimatedFraction();
+        if (!isChildAnimStart && f > 0.618F) {
+          isChildAnimStart = true;
+          final List<Animator> childAnimators = new ArrayList<>(targetGroup.getChildCount());
+          for (int i = 0; i < targetGroup.getChildCount(); i++) {
+            View targetChild = targetGroup.getChildAt(i);
+            ObjectAnimator alphaChild = ObjectAnimator.ofFloat(targetChild, "alpha", 0, 1);
+            if (alphaInterpolator != null)
+              alphaChild.setInterpolator(alphaInterpolator);
+            alphaChild.setStartDelay(18 * i);
+            alphaChild.setDuration(50);
+            childAnimators.add(alphaChild);
+          }
+          AnimatorSet set = new AnimatorSet();
+          set.playTogether(childAnimators);
+          set.start();
+        }
+      }
+    });
+    return set;
+  }
+
+  // DelayedZoomOut
+
+  @NonNull
+  public static Animator createDelayedZoomOutAnim(@NonNull final View target) {
+    return createDelayedZoomOutAnim(target, 0.5F, 0.5F);
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+                                                  int centerX,
+                                                  int centerY) {
+    return createDelayedZoomOutAnim(target, centerX, centerY,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+                                                  float centerPercentX,
+                                                  float centerPercentY) {
+    return createDelayedZoomOutAnim(target, centerPercentX, centerPercentY,
+            createDefInterpolator1(), createDefInterpolator2());
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+                                                  float centerPercentX,
+                                                  float centerPercentY,
+                                                  @Nullable TimeInterpolator zoomInterpolator,
+                                                  @Nullable TimeInterpolator alphaInterpolator) {
+    int centerX = (int) (target.getMeasuredWidth() * centerPercentX);
+    int centerY = (int) (target.getMeasuredHeight() * centerPercentY);
+    return createDelayedZoomOutAnim(target, centerX, centerY, zoomInterpolator, alphaInterpolator);
+  }
+
+  @NonNull
+  public static Animator createDelayedZoomOutAnim(@NonNull final View target,
+                                                  int centerX,
+                                                  int centerY,
+                                                  @Nullable TimeInterpolator zoomInterpolator,
+                                                  @Nullable TimeInterpolator alphaInterpolator) {
+    if (!(target instanceof ViewGroup)) {
+      return createZoomInAnim(target, centerX, centerY);
+    }
+    ViewGroup targetGroup = (ViewGroup) target;
+    targetGroup.setPivotX(centerX);
+    targetGroup.setPivotY(centerY);
+    ObjectAnimator scaleX = ObjectAnimator.ofFloat(targetGroup, "scaleX", targetGroup.getScaleX(), 0);
+    ObjectAnimator scaleY = ObjectAnimator.ofFloat(targetGroup, "scaleY", targetGroup.getScaleY(), 0);
+    if (zoomInterpolator != null) {
+      scaleX.setInterpolator(zoomInterpolator);
+      scaleY.setInterpolator(zoomInterpolator);
+    }
+    AnimatorSet set = new AnimatorSet();
+    set.playTogether(scaleX, scaleY);
+    scaleX.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      private boolean isChildAnimStart = false;
+
+      @Override
+      public void onAnimationUpdate(ValueAnimator animation) {
+        if (!isChildAnimStart) {
+          isChildAnimStart = true;
+          final List<Animator> childAnimators = new ArrayList<>(targetGroup.getChildCount());
+          for (int i = targetGroup.getChildCount() - 1; i >= 0; i--) {
+            View targetChild = targetGroup.getChildAt(i);
+            ObjectAnimator alphaChild = ObjectAnimator.ofFloat(targetChild, "alpha", targetChild.getAlpha(), 0);
+            if (alphaInterpolator != null)
+              alphaChild.setInterpolator(alphaInterpolator);
+            alphaChild.setStartDelay(18 * (targetGroup.getChildCount() - 1 - i));
+            alphaChild.setDuration(50);
+            childAnimators.add(alphaChild);
+          }
+          AnimatorSet set = new AnimatorSet();
+          set.playTogether(childAnimators);
+          set.start();
+        }
+      }
+    });
+    return set;
+  }
 }

--- a/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
+++ b/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
@@ -191,17 +191,8 @@ public class NormalActivity extends AppCompatActivity implements View.OnClickLis
             dialogLayer.contentView(R.layout.dialog_reply)
                     .backgroundDimDefault()
                     .gravity(Gravity.BOTTOM)
-//                    .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                    .compatSoftInput(true)
-                    .onClickToDismiss(R.id.fl_dialog_no)
-                    .onClick(new Layer.OnClickListener() {
-                      @Override
-                      public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                        anyLayer.dismiss();
-                        EditText et = anyLayer.getView(R.id.et_dialog_content);
-                        Toast.makeText(NormalActivity.this, et.getText().toString(), Toast.LENGTH_SHORT).show();
-                      }
-                    }, R.id.fl_dialog_yes)
+                    .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                    .compatSoftInput(true,true)
                     .show();
 
             EditText et = dialogLayer.getView(R.id.et_dialog_content);

--- a/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
+++ b/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
@@ -169,7 +169,7 @@ public class NormalActivity extends AppCompatActivity implements View.OnClickLis
                         .backgroundDimDefault()
                         .gravity(Gravity.BOTTOM)
                         .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                        .compatSoftInput(false)
+//                        .compatSoftInput(false)
                         .compatSoftInput(true, R.id.et_dialog_content4)
                         .onClickToDismiss(R.id.fl_dialog_no)
                         .onClick(new Layer.OnClickListener() {

--- a/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
+++ b/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
@@ -33,727 +33,756 @@ import per.goweii.anylayer.widget.SwipeLayout;
 
 public class NormalActivity extends AppCompatActivity implements View.OnClickListener {
 
-    private DialogLayer anyLayer_show_target_right = null;
-    private boolean anyLayer_show_target_right_shown = false;
-    private DialogLayer anyLayer_show_target_bottom = null;
-    private Layer layer_dark_bg;
+  private DialogLayer anyLayer_show_target_right = null;
+  private boolean anyLayer_show_target_right_shown = false;
+  private DialogLayer anyLayer_show_target_bottom = null;
+  private Layer layer_dark_bg;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_normal);
-        initView();
-    }
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_normal);
+    initView();
+  }
 
-    private void initView() {
-        findViewById(R.id.tv_show_toast).setOnClickListener(this);
-        findViewById(R.id.tv_show_notification).setOnClickListener(this);
-        findViewById(R.id.tv_show_edit).setOnClickListener(this);
-        findViewById(R.id.tv_show_full).setOnClickListener(this);
-        findViewById(R.id.tv_show_app_context).setOnClickListener(this);
-        findViewById(R.id.tv_show_no_context).setOnClickListener(this);
-        findViewById(R.id.tv_show_delay).setOnClickListener(this);
-        findViewById(R.id.tv_show_top).setOnClickListener(this);
-        findViewById(R.id.tv_show_target_full).setOnClickListener(this);
-        findViewById(R.id.tv_show_target_right).setOnClickListener(this);
-        findViewById(R.id.tv_show_target_top).setOnClickListener(this);
-        findViewById(R.id.tv_show_target_bottom).setOnClickListener(this);
-        findViewById(R.id.tv_show_target_left).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom).setOnClickListener(this);
-        findViewById(R.id.tv_show_blur_bg).setOnClickListener(this);
-        findViewById(R.id.tv_show_dark_bg).setOnClickListener(this);
-        findViewById(R.id.tv_show_tran_bg).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom_alpha_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom_zoom_alpha_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_top_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_top_alpha_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_top_bottom).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom_top).setOnClickListener(this);
-        findViewById(R.id.tv_show_top_bottom_alpha).setOnClickListener(this);
-        findViewById(R.id.tv_show_bottom_top_alpha).setOnClickListener(this);
-        findViewById(R.id.tv_show_left_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_left_alpha_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_right_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_right_alpha_in).setOnClickListener(this);
-        findViewById(R.id.tv_show_left_right).setOnClickListener(this);
-        findViewById(R.id.tv_show_right_left).setOnClickListener(this);
-        findViewById(R.id.tv_show_left_right_alpha).setOnClickListener(this);
-        findViewById(R.id.tv_show_right_left_alpha).setOnClickListener(this);
-        findViewById(R.id.tv_show_reveal).setOnClickListener(this);
-        CardView floatCardView = new CardView(this);
-        ImageView floatIconView = new ImageView(this);
-        floatIconView.setImageResource(R.mipmap.ic_launcher_foreground);
-        floatIconView.setScaleType(ImageView.ScaleType.FIT_CENTER);
-        floatIconView.setBackgroundResource(R.color.colorPrimary);
-        floatCardView.addView(floatIconView);
-        floatCardView.setCardBackgroundColor(Color.TRANSPARENT);
-        floatCardView.setRadius(90);
-        floatCardView.setLayoutParams(new ViewGroup.LayoutParams(180, 180));
-        new FloatLayer(this)
-                .floatView(floatCardView)
-                .snapEdge(FloatLayer.Edge.ALL)
-                .outside(true)
-                .defPercentX(1)
-                .defPercentY(0.6F)
-                .defAlpha(0F)
-                .defScale(0F)
-                .normalAlpha(0.9F)
-                .normalScale(1)
-                .lowProfileDelay(3000)
-                .lowProfileAlpha(0.6F)
-                .lowProfileScale(0.9F)
-                .lowProfileIndent(0.5F)
-                .paddingLeft(45)
-                .paddingTop(45)
-                .paddingRight(45)
-                .paddingBottom(45)
-                .marginLeft(0)
-                .marginTop(0)
-                .marginRight(0)
-                .marginBottom(0)
-                .onFloatClick(new Layer.OnClickListener() {
-                    @Override
-                    public void onClick(@NonNull Layer layer, @NonNull View v) {
-                        AnyLayer.toast().message("点击了悬浮按钮").gravity(Gravity.CENTER).show();
-                    }
+  private void initView() {
+    findViewById(R.id.tv_show_toast).setOnClickListener(this);
+    findViewById(R.id.tv_show_notification).setOnClickListener(this);
+    findViewById(R.id.tv_show_edit).setOnClickListener(this);
+    findViewById(R.id.tv_show_edit_1).setOnClickListener(this);
+    findViewById(R.id.tv_show_full).setOnClickListener(this);
+    findViewById(R.id.tv_show_app_context).setOnClickListener(this);
+    findViewById(R.id.tv_show_no_context).setOnClickListener(this);
+    findViewById(R.id.tv_show_delay).setOnClickListener(this);
+    findViewById(R.id.tv_show_top).setOnClickListener(this);
+    findViewById(R.id.tv_show_target_full).setOnClickListener(this);
+    findViewById(R.id.tv_show_target_right).setOnClickListener(this);
+    findViewById(R.id.tv_show_target_top).setOnClickListener(this);
+    findViewById(R.id.tv_show_target_bottom).setOnClickListener(this);
+    findViewById(R.id.tv_show_target_left).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom).setOnClickListener(this);
+    findViewById(R.id.tv_show_blur_bg).setOnClickListener(this);
+    findViewById(R.id.tv_show_dark_bg).setOnClickListener(this);
+    findViewById(R.id.tv_show_tran_bg).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom_alpha_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom_zoom_alpha_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_top_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_top_alpha_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_top_bottom).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom_top).setOnClickListener(this);
+    findViewById(R.id.tv_show_top_bottom_alpha).setOnClickListener(this);
+    findViewById(R.id.tv_show_bottom_top_alpha).setOnClickListener(this);
+    findViewById(R.id.tv_show_left_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_left_alpha_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_right_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_right_alpha_in).setOnClickListener(this);
+    findViewById(R.id.tv_show_left_right).setOnClickListener(this);
+    findViewById(R.id.tv_show_right_left).setOnClickListener(this);
+    findViewById(R.id.tv_show_left_right_alpha).setOnClickListener(this);
+    findViewById(R.id.tv_show_right_left_alpha).setOnClickListener(this);
+    findViewById(R.id.tv_show_reveal).setOnClickListener(this);
+    CardView floatCardView = new CardView(this);
+    ImageView floatIconView = new ImageView(this);
+    floatIconView.setImageResource(R.mipmap.ic_launcher_foreground);
+    floatIconView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+    floatIconView.setBackgroundResource(R.color.colorPrimary);
+    floatCardView.addView(floatIconView);
+    floatCardView.setCardBackgroundColor(Color.TRANSPARENT);
+    floatCardView.setRadius(90);
+    floatCardView.setLayoutParams(new ViewGroup.LayoutParams(180, 180));
+    new FloatLayer(this)
+            .floatView(floatCardView)
+            .snapEdge(FloatLayer.Edge.ALL)
+            .outside(true)
+            .defPercentX(1)
+            .defPercentY(0.6F)
+            .defAlpha(0F)
+            .defScale(0F)
+            .normalAlpha(0.9F)
+            .normalScale(1)
+            .lowProfileDelay(3000)
+            .lowProfileAlpha(0.6F)
+            .lowProfileScale(0.9F)
+            .lowProfileIndent(0.5F)
+            .paddingLeft(45)
+            .paddingTop(45)
+            .paddingRight(45)
+            .paddingBottom(45)
+            .marginLeft(0)
+            .marginTop(0)
+            .marginRight(0)
+            .marginBottom(0)
+            .onFloatClick(new Layer.OnClickListener() {
+              @Override
+              public void onClick(@NonNull Layer layer, @NonNull View v) {
+                AnyLayer.toast().message("点击了悬浮按钮").gravity(Gravity.CENTER).show();
+              }
+            })
+            .show();
+    Layer dialog = AnyLayer.dialog(this)
+            .contentView(R.layout.dialog_normal)
+            .backgroundDimDefault()
+            .gravity(Gravity.CENTER)
+            .cancelableOnTouchOutside(true)
+            .cancelableOnClickKeyBack(true)
+            .onClickToDismiss(R.id.fl_dialog_no);
+    dialog.show();
+    dialog.dismiss();
+  }
+
+  private Random mRandom = new Random();
+
+  @Override
+  public void onClick(View v) {
+    switch (v.getId()) {
+      default:
+        break;
+      case R.id.tv_show_toast:
+        boolean isSucc = mRandom.nextBoolean();
+        AnyLayer.toast()
+                .icon(isSucc ? R.drawable.ic_success : R.drawable.ic_fail)
+                .message(isSucc ? "哈哈，成功了" : "哎呀，失败了")
+                .textColorInt(Color.WHITE)
+                .backgroundColorRes(isSucc ? R.color.colorPrimary : R.color.colorAccent)
+                .gravity(Gravity.CENTER)
+                .show();
+        break;
+      case R.id.tv_show_notification:
+        AnyLayer.globalConfig().notificationTimePattern = "HH:mm";
+        AnyLayer.globalConfig().notificationIcon = getResources().getDrawable(R.drawable.ic_notificstion);
+        AnyLayer.globalConfig().notificationLabel = getString(R.string.app_name);
+        new NotificationLayer(this)
+                .title("这是一个通知")
+                .desc(R.string.dialog_msg)
+                .onNotificationClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer layer, @NonNull View view) {
+                    findViewById(R.id.tv_show_toast).performLongClick();
+                    layer.dismiss();
+                  }
                 })
                 .show();
-        Layer dialog = AnyLayer.dialog(this)
+        break;
+      case R.id.tv_show_edit:
+        DialogLayer layer = AnyLayer.dialog(NormalActivity.this);
+        layer.contentView(R.layout.dialog_edit)
+                .backgroundDimDefault()
+                .gravity(Gravity.BOTTOM)
+                .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                .compatSoftInput(false)
+                .compatSoftInput(true, R.id.et_dialog_content4)
+                .onClickToDismiss(R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                    EditText et = anyLayer.getView(R.id.et_dialog_content);
+                    Toast.makeText(NormalActivity.this, et.getText().toString(), Toast.LENGTH_SHORT).show();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+
+      case R.id.tv_show_edit_1:
+        AnyLayer.dialog(new LayerActivity.OnLayerCreatedCallback() {
+          @Override
+          public void onLayerCreated(@NonNull DialogLayer dialogLayer) {
+            dialogLayer.contentView(R.layout.dialog_reply)
+                    .backgroundDimDefault()
+                    .gravity(Gravity.BOTTOM)
+//                    .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                    .compatSoftInput(true)
+                    .onClickToDismiss(R.id.fl_dialog_no)
+                    .onClick(new Layer.OnClickListener() {
+                      @Override
+                      public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                        anyLayer.dismiss();
+                        EditText et = anyLayer.getView(R.id.et_dialog_content);
+                        Toast.makeText(NormalActivity.this, et.getText().toString(), Toast.LENGTH_SHORT).show();
+                      }
+                    }, R.id.fl_dialog_yes)
+                    .show();
+
+            EditText et = dialogLayer.getView(R.id.et_dialog_content);
+            et.requestFocus();
+          }
+        });
+
+
+        break;
+      case R.id.tv_show_full:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_fullscreen)
+                .onClickToDismiss(R.id.iv_1)
+                .show();
+        break;
+      case R.id.tv_show_app_context:
+        AnyLayer.dialog(new LayerActivity.OnLayerCreatedCallback() {
+          @Override
+          public void onLayerCreated(@NonNull DialogLayer anyLayer) {
+            anyLayer.contentView(R.layout.dialog_normal)
+                    .backgroundDimDefault()
+                    .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                    .show();
+          }
+        });
+        break;
+      case R.id.tv_show_no_context:
+        AnyLayer.dialog()
                 .contentView(R.layout.dialog_normal)
                 .backgroundDimDefault()
-                .gravity(Gravity.CENTER)
-                .cancelableOnTouchOutside(true)
-                .cancelableOnClickKeyBack(true)
-                .onClickToDismiss(R.id.fl_dialog_no);
-        dialog.show();
-        dialog.dismiss();
-    }
-
-    private Random mRandom = new Random();
-
-    @Override
-    public void onClick(View v) {
-        switch (v.getId()) {
-            default:
-                break;
-            case R.id.tv_show_toast:
-                boolean isSucc = mRandom.nextBoolean();
-                AnyLayer.toast()
-                        .icon(isSucc ? R.drawable.ic_success : R.drawable.ic_fail)
-                        .message(isSucc ? "哈哈，成功了" : "哎呀，失败了")
-                        .textColorInt(Color.WHITE)
-                        .backgroundColorRes(isSucc ? R.color.colorPrimary : R.color.colorAccent)
-                        .gravity(Gravity.CENTER)
-                        .show();
-                break;
-            case R.id.tv_show_notification:
-                AnyLayer.globalConfig().notificationTimePattern = "HH:mm";
-                AnyLayer.globalConfig().notificationIcon = getResources().getDrawable(R.drawable.ic_notificstion);
-                AnyLayer.globalConfig().notificationLabel = getString(R.string.app_name);
-                new NotificationLayer(this)
-                        .title("这是一个通知")
-                        .desc(R.string.dialog_msg)
-                        .onNotificationClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer layer, @NonNull View view) {
-                                findViewById(R.id.tv_show_toast).performLongClick();
-                                layer.dismiss();
-                            }
-                        })
-                        .show();
-                break;
-            case R.id.tv_show_edit:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_edit)
-                        .backgroundDimDefault()
-                        .gravity(Gravity.BOTTOM)
-                        .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-//                        .compatSoftInput(false)
-                        .compatSoftInput(true, R.id.et_dialog_content4)
-                        .onClickToDismiss(R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                                EditText et = anyLayer.getView(R.id.et_dialog_content);
-                                Toast.makeText(NormalActivity.this, et.getText().toString(), Toast.LENGTH_SHORT).show();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_full:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_fullscreen)
-                        .onClickToDismiss(R.id.iv_1)
-                        .show();
-                break;
-            case R.id.tv_show_app_context:
-                AnyLayer.dialog(new LayerActivity.OnLayerCreatedCallback() {
-                    @Override
-                    public void onLayerCreated(@NonNull DialogLayer anyLayer) {
-                        anyLayer.contentView(R.layout.dialog_normal)
-                                .backgroundDimDefault()
-                                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                                .show();
-                    }
-                });
-                break;
-            case R.id.tv_show_no_context:
-                AnyLayer.dialog()
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .show();
-                break;
-            case R.id.tv_show_delay:
-                App.sHandler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        AnyLayer.dialog(NormalActivity.this)
-                                .contentView(R.layout.dialog_normal)
-                                .backgroundDimDefault()
-                                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                                .show();
-                    }
-                }, 5000);
-                break;
-            case R.id.tv_show_top:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_match_width)
-                        .avoidStatusBar(true)
-                        .backgroundDimDefault()
-                        .gravity(Gravity.TOP)
-                        .swipeDismiss(SwipeLayout.Direction.TOP)
-                        .onClickToDismiss(R.id.fl_dialog_no)
-                        .show();
-                break;
-            case R.id.tv_show_target_full:
-                AnyLayer.popup(findViewById(R.id.tv_show_target_full))
-                        .contentView(R.layout.dialog_fullscreen)
-                        .animStyle(DialogLayer.AnimStyle.TOP)
-                        .show();
-                break;
-            case R.id.tv_show_target_right:
-                if (anyLayer_show_target_right == null) {
-                    anyLayer_show_target_right = AnyLayer.popup(findViewById(R.id.tv_show_target_right))
-                            .align(Align.Direction.HORIZONTAL, Align.Horizontal.TO_RIGHT, Align.Vertical.CENTER, false)
-                            .outsideInterceptTouchEvent(false)
-                            .contentView(R.layout.popup_normal)
-                            .animStyle(DialogLayer.AnimStyle.LEFT);
-                }
-                if (anyLayer_show_target_right_shown) {
-                    anyLayer_show_target_right_shown = false;
-                    anyLayer_show_target_right.dismiss();
-                } else {
-                    anyLayer_show_target_right_shown = true;
-                    anyLayer_show_target_right.show();
-                }
-                break;
-            case R.id.tv_show_target_left:
-                AnyLayer.popup(findViewById(R.id.tv_show_target_left))
-                        .align(Align.Direction.HORIZONTAL, Align.Horizontal.TO_LEFT, Align.Vertical.CENTER, true)
-                        .contentView(R.layout.popup_normal)
-                        .animStyle(DialogLayer.AnimStyle.RIGHT)
-                        .show();
-                break;
-            case R.id.tv_show_target_top:
-                AnyLayer.popup(findViewById(R.id.tv_show_target_top))
-                        .align(Align.Direction.VERTICAL, Align.Horizontal.CENTER, Align.Vertical.ABOVE, true)
-                        .contentView(R.layout.popup_match_width)
-                        .backgroundDimDefault()
-                        .gravity(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL)
-                        .animStyle(DialogLayer.AnimStyle.BOTTOM)
-                        .show();
-                break;
-            case R.id.tv_show_target_bottom:
-                if (anyLayer_show_target_bottom == null) {
-                    anyLayer_show_target_bottom = AnyLayer.popup(findViewById(R.id.tv_show_target_bottom))
-                            .align(Align.Direction.VERTICAL, Align.Horizontal.CENTER, Align.Vertical.BELOW, false)
-                            .contentClip(false)
-                            .outsideInterceptTouchEvent(false)
-                            .outsideTouchedToDismiss(true)
-                            .contentView(R.layout.popup_meun)
-                            .contentAnimator(new DialogLayer.AnimatorCreator() {
-                                @Override
-                                public Animator createInAnimator(@NonNull View content) {
-                                    return AnimatorHelper.createDelayedZoomInAnim(content, 0.5F, 0F);
-                                }
-
-                                @Override
-                                public Animator createOutAnimator(@NonNull View content) {
-                                    return AnimatorHelper.createDelayedZoomOutAnim(content, 0.5F, 0F);
-                                }
-                            });
-                }
-                if (anyLayer_show_target_bottom.isShown()) {
-//                    anyLayer_show_target_bottom.dismiss();
-                } else {
-                    anyLayer_show_target_bottom.show();
-                }
-                break;
-            case R.id.tv_show_bottom:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_list)
-                        .backgroundDimDefault()
-                        .gravity(Gravity.BOTTOM)
-                        .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                        .onClickToDismiss(R.id.fl_dialog_no)
-                        .show();
-                break;
-            case R.id.tv_show_blur_bg:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_icon)
-                        .backgroundBlurPercent(0.05f)
-                        .backgroundColorInt(getResources().getColor(R.color.dialog_blur_bg))
-                        .show();
-                break;
-            case R.id.tv_show_dark_bg:
-                if (layer_dark_bg == null) {
-                    layer_dark_bg = AnyLayer.dialog(NormalActivity.this)
-                            .contentView(R.layout.dialog_normal)
-                            .backgroundDimDefault()
-                            .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                            .onInitialize(new Layer.OnInitialize() {
-                                @Override
-                                public void onInit(@NonNull Layer layer) {
-                                    TextView tv_dialog_content = layer.getView(R.id.tv_dialog_content);
-                                    tv_dialog_content.setText("这是第一次初始化时绑定的数据" + Math.random());
-                                }
-                            })
-                            .bindData(new Layer.DataBinder() {
-                                @Override
-                                public void bindData(@NonNull Layer layer) {
-                                    TextView tv_dialog_title = layer.getView(R.id.tv_dialog_title);
-                                    tv_dialog_title.setText("标题View$" + System.identityHashCode(tv_dialog_title));
-                                }
-                            })
-                            .onClick(new Layer.OnClickListener() {
-                                @Override
-                                public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                    anyLayer.dismiss();
-                                }
-                            }, R.id.fl_dialog_yes);
-                }
-                layer_dark_bg.show();
-                break;
-            case R.id.tv_show_tran_bg:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_bottom_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_bottom_alpha_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                        .swipeTransformer(new DialogLayer.SwipeTransformer() {
-                            @Override
-                            public void onSwiping(@NonNull DialogLayer layer,
-                                                  @SwipeLayout.Direction int direction,
-                                                  @FloatRange(from = 0F, to = 1F) float fraction) {
-                                layer.getViewHolder().getContent().setAlpha(1 - fraction);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_bottom_zoom_alpha_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                AnimatorSet set = new AnimatorSet();
-                                Animator a1 = AnimatorHelper.createBottomAlphaInAnim(content, 0.3F);
-                                a1.setInterpolator(new DecelerateInterpolator(2.5f));
-                                Animator a2 = AnimatorHelper.createZoomAlphaInAnim(content, 0.9F);
-                                a2.setInterpolator(new DecelerateInterpolator(1.5f));
-                                set.playTogether(a1, a2);
-                                return set;
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                AnimatorSet set = new AnimatorSet();
-                                Animator a1 = AnimatorHelper.createBottomAlphaOutAnim(content, 0.3F);
-                                a1.setInterpolator(new DecelerateInterpolator(1.5f));
-                                Animator a2 = AnimatorHelper.createZoomAlphaOutAnim(content, 0.9F);
-                                a2.setInterpolator(new DecelerateInterpolator(2.5f));
-                                set.playTogether(a1, a2);
-                                return set;
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .show();
-                break;
-            case R.id.tv_show_top_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .swipeDismiss(SwipeLayout.Direction.TOP)
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_top_alpha_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_top_bottom:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createBottomOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_bottom_top:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createBottomInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_top_bottom_alpha:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createBottomAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_bottom_top_alpha:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createBottomAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createTopAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_left_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .swipeDismiss(SwipeLayout.Direction.LEFT)
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_left_alpha_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_right_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .swipeDismiss(SwipeLayout.Direction.RIGHT)
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_right_alpha_in:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_left_right:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_right_left:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_left_right_alpha:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_right_left_alpha:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                return AnimatorHelper.createRightAlphaInAnim(content);
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                return AnimatorHelper.createLeftAlphaOutAnim(content);
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
-            case R.id.tv_show_reveal:
-                AnyLayer.dialog(NormalActivity.this)
-                        .contentView(R.layout.dialog_normal)
-                        .backgroundDimDefault()
-                        .contentAnimator(new DialogLayer.AnimatorCreator() {
-                            @Override
-                            public Animator createInAnimator(@NonNull View content) {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                    return AnimatorHelper.createCircularRevealInAnim(content, content.getMeasuredWidth() / 2, content.getMeasuredHeight() / 2);
-                                } else {
-                                    return null;
-                                }
-                            }
-
-                            @Override
-                            public Animator createOutAnimator(@NonNull View content) {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                                    return AnimatorHelper.createCircularRevealOutAnim(content, content.getMeasuredWidth() / 2, content.getMeasuredHeight() / 2);
-                                } else {
-                                    return null;
-                                }
-                            }
-                        })
-                        .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
-                        .onClick(new Layer.OnClickListener() {
-                            @Override
-                            public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
-                                anyLayer.dismiss();
-                            }
-                        }, R.id.fl_dialog_yes)
-                        .show();
-                break;
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .show();
+        break;
+      case R.id.tv_show_delay:
+        App.sHandler.postDelayed(new Runnable() {
+          @Override
+          public void run() {
+            AnyLayer.dialog(NormalActivity.this)
+                    .contentView(R.layout.dialog_normal)
+                    .backgroundDimDefault()
+                    .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                    .show();
+          }
+        }, 5000);
+        break;
+      case R.id.tv_show_top:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_match_width)
+                .avoidStatusBar(true)
+                .backgroundDimDefault()
+                .gravity(Gravity.TOP)
+                .swipeDismiss(SwipeLayout.Direction.TOP)
+                .onClickToDismiss(R.id.fl_dialog_no)
+                .show();
+        break;
+      case R.id.tv_show_target_full:
+        AnyLayer.popup(findViewById(R.id.tv_show_target_full))
+                .contentView(R.layout.dialog_fullscreen)
+                .animStyle(DialogLayer.AnimStyle.TOP)
+                .show();
+        break;
+      case R.id.tv_show_target_right:
+        if (anyLayer_show_target_right == null) {
+          anyLayer_show_target_right = AnyLayer.popup(findViewById(R.id.tv_show_target_right))
+                  .align(Align.Direction.HORIZONTAL, Align.Horizontal.TO_RIGHT, Align.Vertical.CENTER, false)
+                  .outsideInterceptTouchEvent(false)
+                  .contentView(R.layout.popup_normal)
+                  .animStyle(DialogLayer.AnimStyle.LEFT);
         }
+        if (anyLayer_show_target_right_shown) {
+          anyLayer_show_target_right_shown = false;
+          anyLayer_show_target_right.dismiss();
+        } else {
+          anyLayer_show_target_right_shown = true;
+          anyLayer_show_target_right.show();
+        }
+        break;
+      case R.id.tv_show_target_left:
+        AnyLayer.popup(findViewById(R.id.tv_show_target_left))
+                .align(Align.Direction.HORIZONTAL, Align.Horizontal.TO_LEFT, Align.Vertical.CENTER, true)
+                .contentView(R.layout.popup_normal)
+                .animStyle(DialogLayer.AnimStyle.RIGHT)
+                .show();
+        break;
+      case R.id.tv_show_target_top:
+        AnyLayer.popup(findViewById(R.id.tv_show_target_top))
+                .align(Align.Direction.VERTICAL, Align.Horizontal.CENTER, Align.Vertical.ABOVE, true)
+                .contentView(R.layout.popup_match_width)
+                .backgroundDimDefault()
+                .gravity(Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL)
+                .animStyle(DialogLayer.AnimStyle.BOTTOM)
+                .show();
+        break;
+      case R.id.tv_show_target_bottom:
+        if (anyLayer_show_target_bottom == null) {
+          anyLayer_show_target_bottom = AnyLayer.popup(findViewById(R.id.tv_show_target_bottom))
+                  .align(Align.Direction.VERTICAL, Align.Horizontal.CENTER, Align.Vertical.BELOW, false)
+                  .contentClip(false)
+                  .outsideInterceptTouchEvent(false)
+                  .outsideTouchedToDismiss(true)
+                  .contentView(R.layout.popup_meun)
+                  .contentAnimator(new DialogLayer.AnimatorCreator() {
+                    @Override
+                    public Animator createInAnimator(@NonNull View content) {
+                      return AnimatorHelper.createDelayedZoomInAnim(content, 0.5F, 0F);
+                    }
+
+                    @Override
+                    public Animator createOutAnimator(@NonNull View content) {
+                      return AnimatorHelper.createDelayedZoomOutAnim(content, 0.5F, 0F);
+                    }
+                  });
+        }
+        if (anyLayer_show_target_bottom.isShown()) {
+//                    anyLayer_show_target_bottom.dismiss();
+        } else {
+          anyLayer_show_target_bottom.show();
+        }
+        break;
+      case R.id.tv_show_bottom:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_list)
+                .backgroundDimDefault()
+                .gravity(Gravity.BOTTOM)
+                .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                .onClickToDismiss(R.id.fl_dialog_no)
+                .show();
+        break;
+      case R.id.tv_show_blur_bg:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_icon)
+                .backgroundBlurPercent(0.05f)
+                .backgroundColorInt(getResources().getColor(R.color.dialog_blur_bg))
+                .show();
+        break;
+      case R.id.tv_show_dark_bg:
+        if (layer_dark_bg == null) {
+          layer_dark_bg = AnyLayer.dialog(NormalActivity.this)
+                  .contentView(R.layout.dialog_normal)
+                  .backgroundDimDefault()
+                  .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                  .onInitialize(new Layer.OnInitialize() {
+                    @Override
+                    public void onInit(@NonNull Layer layer) {
+                      TextView tv_dialog_content = layer.getView(R.id.tv_dialog_content);
+                      tv_dialog_content.setText("这是第一次初始化时绑定的数据" + Math.random());
+                    }
+                  })
+                  .bindData(new Layer.DataBinder() {
+                    @Override
+                    public void bindData(@NonNull Layer layer) {
+                      TextView tv_dialog_title = layer.getView(R.id.tv_dialog_title);
+                      tv_dialog_title.setText("标题View$" + System.identityHashCode(tv_dialog_title));
+                    }
+                  })
+                  .onClick(new Layer.OnClickListener() {
+                    @Override
+                    public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                      anyLayer.dismiss();
+                    }
+                  }, R.id.fl_dialog_yes);
+        }
+        layer_dark_bg.show();
+        break;
+      case R.id.tv_show_tran_bg:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_bottom_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_bottom_alpha_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .swipeDismiss(SwipeLayout.Direction.BOTTOM)
+                .swipeTransformer(new DialogLayer.SwipeTransformer() {
+                  @Override
+                  public void onSwiping(@NonNull DialogLayer layer,
+                                        @SwipeLayout.Direction int direction,
+                                        @FloatRange(from = 0F, to = 1F) float fraction) {
+                    layer.getViewHolder().getContent().setAlpha(1 - fraction);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_bottom_zoom_alpha_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    AnimatorSet set = new AnimatorSet();
+                    Animator a1 = AnimatorHelper.createBottomAlphaInAnim(content, 0.3F);
+                    a1.setInterpolator(new DecelerateInterpolator(2.5f));
+                    Animator a2 = AnimatorHelper.createZoomAlphaInAnim(content, 0.9F);
+                    a2.setInterpolator(new DecelerateInterpolator(1.5f));
+                    set.playTogether(a1, a2);
+                    return set;
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    AnimatorSet set = new AnimatorSet();
+                    Animator a1 = AnimatorHelper.createBottomAlphaOutAnim(content, 0.3F);
+                    a1.setInterpolator(new DecelerateInterpolator(1.5f));
+                    Animator a2 = AnimatorHelper.createZoomAlphaOutAnim(content, 0.9F);
+                    a2.setInterpolator(new DecelerateInterpolator(2.5f));
+                    set.playTogether(a1, a2);
+                    return set;
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .show();
+        break;
+      case R.id.tv_show_top_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .swipeDismiss(SwipeLayout.Direction.TOP)
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_top_alpha_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_top_bottom:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createBottomOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_bottom_top:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createBottomInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_top_bottom_alpha:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createBottomAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_bottom_top_alpha:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createBottomAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createTopAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_left_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .swipeDismiss(SwipeLayout.Direction.LEFT)
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_left_alpha_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_right_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .swipeDismiss(SwipeLayout.Direction.RIGHT)
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_right_alpha_in:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_left_right:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_right_left:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_left_right_alpha:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_right_left_alpha:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    return AnimatorHelper.createRightAlphaInAnim(content);
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    return AnimatorHelper.createLeftAlphaOutAnim(content);
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
+      case R.id.tv_show_reveal:
+        AnyLayer.dialog(NormalActivity.this)
+                .contentView(R.layout.dialog_normal)
+                .backgroundDimDefault()
+                .contentAnimator(new DialogLayer.AnimatorCreator() {
+                  @Override
+                  public Animator createInAnimator(@NonNull View content) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                      return AnimatorHelper.createCircularRevealInAnim(content, content.getMeasuredWidth() / 2, content.getMeasuredHeight() / 2);
+                    } else {
+                      return null;
+                    }
+                  }
+
+                  @Override
+                  public Animator createOutAnimator(@NonNull View content) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                      return AnimatorHelper.createCircularRevealOutAnim(content, content.getMeasuredWidth() / 2, content.getMeasuredHeight() / 2);
+                    } else {
+                      return null;
+                    }
+                  }
+                })
+                .onClickToDismiss(R.id.fl_dialog_yes, R.id.fl_dialog_no)
+                .onClick(new Layer.OnClickListener() {
+                  @Override
+                  public void onClick(@NonNull Layer anyLayer, @NonNull View v) {
+                    anyLayer.dismiss();
+                  }
+                }, R.id.fl_dialog_yes)
+                .show();
+        break;
     }
+  }
 }
 

--- a/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
+++ b/app/src/main/java/per/goweii/android/anylayer/NormalActivity.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 
 import androidx.annotation.FloatRange;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.cardview.widget.CardView;
 
@@ -191,15 +192,28 @@ public class NormalActivity extends AppCompatActivity implements View.OnClickLis
             dialogLayer.contentView(R.layout.dialog_reply)
                     .backgroundDimDefault()
                     .gravity(Gravity.BOTTOM)
+                    //目前的 swipe bottom 中包含的 bottomIn 动画会使出场错位，所以需要自己另外再安排一个动画来覆盖
                     .swipeDismiss(SwipeLayout.Direction.BOTTOM)
-                    .compatSoftInput(true,true)
+                    .compatSoftInput(true)
+                    .contentAnimator(new Layer.AnimatorCreator() {
+                      @Nullable
+                      @Override
+                      public Animator createInAnimator(@NonNull View target) {
+                        return AnimatorHelper.createAlphaInAnim(target);
+                      }
+
+                      @Nullable
+                      @Override
+                      public Animator createOutAnimator(@NonNull View target) {
+                        return AnimatorHelper.createBottomOutAnim(target);
+                      }
+                    })
                     .show();
 
             EditText et = dialogLayer.getView(R.id.et_dialog_content);
             et.requestFocus();
           }
         });
-
 
         break;
       case R.id.tv_show_full:

--- a/app/src/main/res/layout/activity_normal.xml
+++ b/app/src/main/res/layout/activity_normal.xml
@@ -46,6 +46,15 @@
                     android:textSize="14sp" />
 
                 <TextView
+                    android:id="@+id/tv_show_edit_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:gravity="center"
+                    android:text="回复框"
+                    android:textColor="#232323"
+                    android:textSize="14sp" />
+
+                <TextView
                     android:id="@+id/tv_show_full"
                     android:layout_width="match_parent"
                     android:layout_height="60dp"

--- a/app/src/main/res/layout/dialog_reply.xml
+++ b/app/src/main/res/layout/dialog_reply.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:orientation="vertical">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/dialog_white_bg">
+
+        <TextView
+            android:id="@+id/tv_dialog_title"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_alignParentLeft="true"
+            android:gravity="center_vertical"
+            android:paddingLeft="12dp"
+            android:text="回复"
+            android:textColor="#232323"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/tv_dialog_send"
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:layout_alignParentRight="true"
+            android:gravity="center_vertical"
+            android:paddingRight="12dp"
+            android:text="发送"
+            android:textColor="#232323"
+            android:textSize="16sp" />
+
+    </RelativeLayout>
+
+    <EditText
+        android:id="@+id/et_dialog_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/colorPrimary"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:gravity="left"
+        android:hint="请输入回复的内容"
+        android:paddingLeft="20dp"
+        android:paddingTop="28dp"
+        android:paddingRight="20dp"
+        android:paddingBottom="25dp"
+        android:textColor="#232323"
+        android:textSize="17sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
     <color name="colorAccent">#FB5252</color>
 
     <color name="dialog_blur_bg">#33ffffff</color>
+    <color name="dialog_white_bg">#ffffff</color>
 </resources>


### PR DESCRIPTION
更新说明：

1.使 LayerActivity 继承于 AppCompatActivity，以便使用者有机会在 callback 中使用 LayerActivity 作用域的 ViewModel。

2.解决 LayerActivity callback 方式启动 DialogLayer 的情况下 关闭 dialog 时存在的内存泄漏问题。

3.添加 “回复框” 的使用示例，场景需求是 “让回复框底部与键盘无缝相连”，

目前框架的状况是，SwipeLayout.Direction.BOTTOM 默认指定的入场动画会导致 dialog 入场时在 y 方向上发生偏移，

目前采取的非入侵解决办法是：在链式调用中设置进出动画，来覆盖 swipe bottom 导致的默认动画。

